### PR TITLE
Refine retro-modern portfolio section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,10 @@
 
         <!-- About Section -->
         <section id="about" class="fade-in" aria-labelledby="aboutTitle" data-parallax-section>
-            <h2 id="aboutTitle" class="section-title">Über mich</h2>
+            <div class="section-heading">
+                <h2 id="aboutTitle" class="section-title">Über mich</h2>
+                <p class="section-lead">Retro im Look, klar in der Führung: Ich verbinde Design, Code und Produktdenken zu Interfaces, die schnell verstanden werden.</p>
+            </div>
             <div class="about-content">
                 <div class="about-text">
                     <h3>Hallo, ich bin Daniel!</h3>
@@ -385,7 +388,10 @@
 
         <!-- Projects Section -->
         <section id="projects" class="fade-in" data-parallax-section>
-            <h2 class="section-title">Meine Projekte</h2>
+            <div class="section-heading">
+                <h2 class="section-title">Meine Projekte</h2>
+                <p class="section-lead">Ausgewählte Arbeiten mit monochromem Charakter, reduzierter UI und Fokus auf Tempo, Lesbarkeit und Nutzbarkeit.</p>
+            </div>
             <div class="projects-grid">
                 <div class="project-card">
                     <a href="/website.html" aria-label="Projektseite: Meine Website">
@@ -471,7 +477,10 @@
 
         <!-- Contact Section -->
         <section id="contact" class="fade-in" aria-labelledby="contactTitle">
-            <h2 id="contactTitle" class="section-title">Kontakt</h2>
+            <div class="section-heading">
+                <h2 id="contactTitle" class="section-title">Kontakt</h2>
+                <p class="section-lead">Direkt, reduziert und ohne Umwege: Wenn du ein Projekt, ein Produkt oder ein digitales Erlebnis verbessern willst, lass uns sprechen.</p>
+            </div>
             <div class="contact-terminal">
                 <div class="terminal-header">
                     <div class="terminal-buttons">

--- a/src/css/about.css
+++ b/src/css/about.css
@@ -1,15 +1,20 @@
 /* About Section */
 .about-content {
     display: grid;
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.3fr);
-    align-items: flex-start;
-    gap: 2.5rem;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1.35fr);
+    align-items: stretch;
+    gap: 1.5rem;
     max-width: 1100px;
     margin: 0 auto;
 }
 
 .about-text {
     text-align: left;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015));
+    border: 1px solid var(--surface-border);
+    border-radius: 16px;
+    padding: 1.75rem;
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.22);
 }
 
 .about-text h3,
@@ -98,8 +103,7 @@
 
 /* Timeline */
 .timeline {
-    margin: 3rem 0;
-    margin-bottom: 4rem;
+    margin: 0;
 }
 
 .timeline-item {
@@ -190,7 +194,7 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 1.25rem;
     max-width: 1100px;
-    margin: 2rem auto 0;
+    margin: 0 auto;
 }
 
 .terminal-card {
@@ -434,10 +438,16 @@
 }
 
 /* CV Download Terminal */
+.cv-actions {
+    width: 100%;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
 .cv-download-terminal {
     background: var(--surface);
     border: 1px solid var(--surface-border);
-    border-radius: 8px;
+    border-radius: 12px;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.35);
     font-family: 'Consolas', 'Monaco', monospace;
     font-size: 14px;
@@ -632,6 +642,7 @@
 
     .about-text {
         text-align: center;
+        padding: 1.35rem;
     }
 
     .about-text h3,

--- a/src/css/components.css
+++ b/src/css/components.css
@@ -39,35 +39,68 @@ main {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2rem;
+    gap: 2.5rem;
 }
 
 section {
-    padding: 6rem 2rem;
+    padding: clamp(4.5rem, 8vw, 6.5rem) 2rem;
     max-width: 1200px;
     margin: 0 auto;
     width: 100%;
     text-align: center;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 2.5rem;
+    position: relative;
+}
+
+section::before {
+    content: '';
+    position: absolute;
+    inset: 1.5rem 0 auto;
+    width: min(180px, 32vw);
+    height: 1px;
+    margin: 0 auto;
+    background: linear-gradient(90deg, transparent, var(--surface-border-strong), transparent);
+    opacity: 0.6;
+}
+
+.section-heading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.85rem;
+    max-width: 720px;
+    margin: 0 auto;
 }
 
 .section-title {
     font-family: 'Orbitron', sans-serif;
-    font-size: clamp(2rem, 5vw, 2.5rem);
+    font-size: clamp(2rem, 5vw, 2.75rem);
     text-align: center;
-    margin-bottom: 3rem;
+    margin: 0;
     color: var(--light);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
 }
 
 .section-title::after {
     content: '';
     display: block;
-    width: 100px;
+    width: 112px;
     height: 3px;
-    background: var(--light);
-    margin: 1rem auto;
+    background: linear-gradient(90deg, transparent, var(--light), transparent);
+    margin: 1rem auto 0;
+    opacity: 0.9;
+}
+
+.section-lead {
+    max-width: 62ch;
+    margin: 0;
+    color: var(--text-muted);
+    font-size: clamp(0.98rem, 1.3vw, 1.08rem);
+    line-height: 1.8;
+    text-wrap: balance;
 }
 
 /* Cards */
@@ -205,4 +238,22 @@ section {
     opacity: 0.7;
 }
 
+@media (max-width: 768px) {
+    section {
+        padding-inline: 1rem;
+        gap: 2rem;
+    }
 
+    section::before {
+        inset-block-start: 1rem;
+    }
+
+    .section-title {
+        letter-spacing: 0.05em;
+    }
+
+    .section-lead {
+        font-size: 0.95rem;
+        line-height: 1.7;
+    }
+}

--- a/src/css/contact.css
+++ b/src/css/contact.css
@@ -1,11 +1,11 @@
 /* Contact Form */
 .contact-terminal {
     border: 1px solid var(--surface-border);
-    background: var(--surface);
-    border-radius: 10px;
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01));
+    border-radius: 16px;
     overflow: hidden;
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
-    max-width: 980px;
+    max-width: 1040px;
     margin: 0 auto;
     transition: box-shadow 0.3s var(--ease-out-quart);
 }
@@ -34,7 +34,7 @@
 }
 
 .contact-shell {
-    padding: 1.6rem 1.5rem 1.5rem;
+    padding: 1.75rem 1.6rem 1.6rem;
     background: radial-gradient(circle at 0 0, rgba(255,255,255,0.04), transparent 55%);
     position: relative;
 }
@@ -52,14 +52,14 @@
 .contact-grid {
     display: grid;
     grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
-    gap: 1.75rem;
+    gap: 1.25rem;
     align-items: start;
 }
 
 .contact-aside {
     background: var(--surface-alt);
     border: 1px solid var(--surface-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: 1.1rem 1rem 1.05rem;
     font-family: 'Space Mono', monospace;
     color: var(--light);
@@ -108,7 +108,7 @@
 .contact-form {
     background: var(--surface-alt);
     border: 1px solid var(--surface-border);
-    border-radius: 8px;
+    border-radius: 12px;
     padding: 1.4rem 1.35rem 1.25rem;
     box-shadow: inset 0 1px 0 rgba(255,255,255,0.03);
 }

--- a/src/css/projects.css
+++ b/src/css/projects.css
@@ -1,24 +1,28 @@
 /* Projects Section - Monochrome Style */
 .projects-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
     gap: 1.5rem;
     align-items: stretch;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
 }
 
 .project-card {
-    background: var(--surface-alt);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.045), rgba(255, 255, 255, 0.015));
     border: 1px solid var(--surface-border);
-    border-radius: 8px;
+    border-radius: 14px;
     overflow: hidden;
-    transition: transform 0.35s var(--ease-out-expo), border-color 0.35s var(--ease-out-expo), box-shadow 0.35s var(--ease-out-expo);
+    transition: transform 0.35s var(--ease-out-expo), border-color 0.35s var(--ease-out-expo), box-shadow 0.35s var(--ease-out-expo), background 0.35s var(--ease-out-expo);
     position: relative;
 }
 
 .project-card:hover {
     transform: translateY(-5px);
     border-color: var(--surface-border-strong);
-    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.07), rgba(255, 255, 255, 0.02));
 }
 
 .project-image {
@@ -65,6 +69,7 @@
 .project-content {
     padding: 1.4rem 1.5rem 1.5rem;
     color: var(--light);
+    text-align: left;
 }
 
 .project-meta {
@@ -127,9 +132,10 @@
 .project-title {
     font-family: 'Orbitron', sans-serif;
     color: var(--light);
-    margin-bottom: 0.4rem;
+    margin-bottom: 0.55rem;
     letter-spacing: 0.06em;
     font-size: 1.05rem;
+    line-height: 1.35;
 }
 
 .project-tech {


### PR DESCRIPTION
### Motivation
- Sektionen sollten zentrierte, wertigere Überschriften und eine kurze Einleitung erhalten, damit die Seite "retro" bleibt, aber sofort verständlich und moderner bedienbar wirkt.
- Inhaltliche Gruppen (About / Projects / Contact) sollten klarer framed und besser lesbar sein, insbesondere auf mobilen Geräten.

### Description
- Füge in `index.html` für About, Projects und Contact Wrapper `.section-heading` mit ergänzender `p.section-lead` ein, um Überschriften zu zentrieren und kontextuelle Kurztexte bereitzustellen.
- Erweitere `src/css/components.css` um zentrale Section-Styles (`.section-heading`, `.section-lead`, `section::before`) und passe globales Section-Spacing an, damit Titel mehr Bühne bekommen und der Rhythmus konsistenter ist.
- Passe `src/css/about.css` an: feinere Grid-Anpassung, visuelle Panel-Behandlung für `.about-text` (Gradient, Radius, Padding, Schatten), Timeline-Spacing und CV-Aktions-Container verfeinert.
- Überarbeite `src/css/projects.css`: reduzierte Mindestbreite der Grid-Items, elegantere Project-Card-Oberflächen (leichte Gradients, größere Radien, Hover-Verbesserungen) und klarere Textausrichtung in `.project-content`.
- Verfeinere `src/css/contact.css`: Panel-Gradient, größere Radien, angepasste Grid-Abstände und Innenabstände für das Kontakt-Formular.

### Testing
- Build: `npm run build` ausgeführt und der Produktions-Build war erfolgreich (Vite build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdcd3c481c8322a136d10a50ec2565)