### PR TITLE
Add full katoro privacy policy

### DIFF
--- a/katoro-privacy.html
+++ b/katoro-privacy.html
@@ -6,7 +6,7 @@
     <title>Datenschutzerklärung – katoro</title>
     <meta name="theme-color" content="#000000">
     <link rel="canonical" href="https://dwidmer.dev/katoro-privacy.html">
-    <meta name="description" content="Datenschutzerklärung für die iOS App katoro von Daniel Widmer.">
+    <meta name="description" content="Datenschutzerklärung für katoro: lokale Speicherung, optionale Apple/Google/Microsoft-Sync, kein Werbe-Tracking. iOS Planungs-App von Daniel Widmer.">
     <style>
         @font-face { font-family:'Space Mono'; font-style:normal; font-weight:400; font-display:swap; src:url('/fonts/space-mono-v17-latin-400.ttf') format('truetype'); }
         @font-face { font-family:'Space Mono'; font-style:normal; font-weight:700; font-display:swap; src:url('/fonts/space-mono-v17-latin-700.woff2') format('woff2'); }
@@ -39,6 +39,8 @@
         .sep { text-align:center; opacity:.4; margin:1.25rem 0; }
         .back { margin-top:1.5rem; display:inline-block; border:1px solid var(--light); padding:.6rem 1rem; border-radius:4px; text-decoration:none; }
         .back:hover { background: var(--light); color: var(--dark); }
+        h2 { font-size:1.15rem; margin-top:1.5rem; margin-bottom:.75rem; }
+        h3 { font-size:1rem; margin-top:1.25rem; margin-bottom:.5rem; }
         ul { margin:.75rem 0; padding-left:1.5rem; }
         ul li { margin-bottom:.35rem; }
         .update-note { opacity:.6; font-size:.85rem; margin-top:1.5rem; }

--- a/katoro-privacy.html
+++ b/katoro-privacy.html
@@ -93,9 +93,102 @@
 
             <div class="sep">⸻</div>
 
-            <p>Die vollständige Datenschutzerklärung für katoro wird hier in Kürze veröffentlicht.</p>
+            <h2>1) Überblick</h2>
+            <p>Der Schutz deiner Daten ist uns wichtig. Diese Datenschutzerklärung erklärt, welche Daten die App katoro verarbeitet und zu welchem Zweck.</p>
+            <p>katoro ist eine Planungs-App für Termine, Aufgaben und Routinen. Wir betreiben keine eigenen Server, auf denen deine Planungsinhalte gespeichert werden. Die Verarbeitung erfolgt überwiegend lokal auf deinem Gerät oder über Dienste, die du aktiv nutzt (z.&nbsp;B. Apple, optional Google oder Microsoft).</p>
+            <p><strong>Werbung und Tracking:</strong> katoro zeigt keine Werbung und verwendet kein werbliches Tracking (kein AdMob o.&nbsp;Ä.).</p>
+            <p><strong>Änderungen an der App:</strong> Wenn katoro durch Updates neue Funktionen erhält, die zusätzliche Daten betreffen, passen wir diese Erklärung an. Die jeweils aktuelle Fassung findest du auf dieser Seite.</p>
 
-            <p class="update-note">Stand: März 2026</p>
+            <div class="sep">⸻</div>
+
+            <h2>2) Welche Daten werden verarbeitet?</h2>
+
+            <h3>a) Daten in der App (lokal auf deinem Gerät)</h3>
+            <p>katoro speichert die von dir erfassten Inhalte und Einstellungen auf deinem Gerät, unter anderem:</p>
+            <ul>
+                <li>Kalendertermine, Aufgaben, Routinen und Reflexionen</li>
+                <li>Notizen, Orte, Listen und Anhänge (sofern du sie nutzt)</li>
+                <li>App-Einstellungen (z.&nbsp;B. Sprache, Darstellung, Synchronisationsoptionen)</li>
+                <li>lokale Sicherungskopien und Exporte (sofern du diese Funktionen nutzt)</li>
+            </ul>
+            <p>Diese Daten werden nicht an uns als Entwickler übermittelt. Sie verlassen dein Gerät nur, wenn du unten beschriebene optionale Dienste aktivierst oder Daten selbst exportierst.</p>
+
+            <div class="sep">⸻</div>
+
+            <h3>b) Apple-Dienste (wenn du sie nutzt oder freigibst)</h3>
+            <p>Je nach deinen Einstellungen und Systemberechtigungen kann die App mit Apple-Diensten auf deinem Gerät zusammenarbeiten:</p>
+            <ul>
+                <li><strong>Kalender und Erinnerungen:</strong> Import und Synchronisation von Terminen und Aufgaben (nur mit deiner Berechtigung)</li>
+                <li><strong>Mitteilungen:</strong> Erinnerungen für Termine, Aufgaben, Routinen und Tagesplan — lokal auf dem Gerät geplant, ohne Push-Benachrichtigungen über unsere Server</li>
+                <li><strong>Standort:</strong> optional für Wetter in «Mein Tag» und für Orts-Erinnerungen bei Aufgaben (nur bei Nutzung der App, wenn du es aktivierst)</li>
+                <li><strong>Wetter:</strong> Anzeige über WeatherKit (Apple), basierend auf Standort oder einem von dir gewählten Ort</li>
+                <li><strong>Apple Health:</strong> Anzeige der Schrittzahl — derzeit werden Schritte ausschliesslich gelesen; katoro schreibt keine Daten in Apple Health</li>
+                <li><strong>iCloud / CloudKit:</strong> optionaler Sync zwischen deinen Geräten mit katoro Pro — Daten liegen in deiner privaten iCloud</li>
+                <li><strong>Widgets und Live Activities:</strong> Anzeige auf Start- und Sperrbildschirm; Datenübertragung nur auf demselben Gerät (App Group)</li>
+                <li><strong>App Store / StoreKit:</strong> Abwicklung von katoro Pro — Zahlungsdaten werden nur von Apple verarbeitet</li>
+            </ul>
+            <p><strong>Weitere Informationen:</strong> <a href="https://www.apple.com/legal/privacy/" target="_blank" rel="noopener">https://www.apple.com/legal/privacy/</a></p>
+
+            <div class="sep">⸻</div>
+
+            <h3>c) Google- und Microsoft-Konto (optional)</h3>
+            <p>Wenn du dein Google- oder Microsoft-Konto in den Einstellungen verbindest, tauscht die App Daten mit diesen Anbietern aus (Kalender und Aufgaben). Dabei können Inhalte deiner Termine und Aufgaben sowie Kontobezeichnungen verarbeitet werden. Anmeldeinformationen (Tokens) werden lokal im iOS-Schlüsselbund gespeichert.</p>
+            <ul>
+                <li>Google Datenschutzerklärung: <a href="https://policies.google.com/privacy" target="_blank" rel="noopener">https://policies.google.com/privacy</a></li>
+                <li>Microsoft Datenschutzerklärung: <a href="https://privacy.microsoft.com" target="_blank" rel="noopener">https://privacy.microsoft.com</a></li>
+            </ul>
+            <p>Eine Verbindung besteht nur, solange du sie nicht in der App trennst.</p>
+
+            <div class="sep">⸻</div>
+
+            <h3>d) Externe Kalender (ICS)</h3>
+            <p>Wenn du eine Kalender-URL (ICS-Feed) hinzufügst, ruft die App diese Adresse ab, um Termine zu importieren. Welche Daten dabei übertragen werden, hängt vom Betreiber des Feeds ab.</p>
+
+            <div class="sep">⸻</div>
+
+            <h3>e) Technische Diagnose (lokal)</h3>
+            <p>Die App kann technische Protokolle lokal auf dem Gerät erzeugen (z.&nbsp;B. zur Fehleranalyse). Diese werden nicht automatisch an uns gesendet. Es findet kein werbliches Profiling statt.</p>
+
+            <div class="sep">⸻</div>
+
+            <h2>3) Speicherung und Speicherdauer</h2>
+            <ul>
+                <li><strong>Lokale App-Daten:</strong> solange du die App nutzt oder bis du Inhalte löschst bzw. die App deinstallierst</li>
+                <li><strong>Verknüpfte Konten (Google/Microsoft):</strong> bis zur Trennung in den Einstellungen</li>
+                <li><strong>iCloud-Sync:</strong> solange du iCloud-Sync aktiviert hast</li>
+                <li><strong>Lokale Backups:</strong> nach den in der App beschriebenen Regeln (z.&nbsp;B. Rotation und Löschung)</li>
+            </ul>
+
+            <div class="sep">⸻</div>
+
+            <h2>4) Weitergabe von Daten</h2>
+            <p>Eine Weitergabe erfolgt nur:</p>
+            <ul>
+                <li>an Apple, soweit du Apple-Funktionen nutzt,</li>
+                <li>an Google oder Microsoft, soweit du ein Konto verbindest,</li>
+                <li>an Betreiber von ICS-Kalendern, die du selbst eingetragen hast.</li>
+            </ul>
+            <p>Es erfolgt keine Weitergabe zu Werbe- oder Trackingzwecken an uns oder Werbepartner.</p>
+            <p>Bei Google und Microsoft kann eine Verarbeitung ausserhalb der Schweiz oder des EWR stattfinden; es gelten die Datenschutzregeln der jeweiligen Anbieter.</p>
+
+            <div class="sep">⸻</div>
+
+            <h2>5) Deine Rechte</h2>
+            <p>Du hast nach anwendbarem Recht (u.&nbsp;a. Schweizer DSG, ggf. DSGVO) unter anderem das Recht auf Auskunft, Berichtigung, Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit (soweit anwendbar) und Widerspruch sowie das Recht, eine Beschwerde bei einer Aufsichtsbehörde einzureichen.</p>
+            <p><strong>Kontakt:</strong> <a href="mailto:widmer.daniel40@gmail.com">widmer.daniel40@gmail.com</a></p>
+            <p>Da die meisten Daten auf deinem Gerät liegen, kannst du sie durch Löschen in der App, Deaktivieren von Sync, Trennen externer Konten oder Deinstallation entfernen. Berechtigungen (Kalender, Health, Standort, Mitteilungen) steuerst du zusätzlich in den iOS-Einstellungen.</p>
+            <p>Anfragen zu Daten bei Apple, Google oder Microsoft richtest du in der Regel auch direkt an diese Anbieter.</p>
+
+            <div class="sep">⸻</div>
+
+            <h2>6) Kinder</h2>
+            <p>katoro richtet sich nicht gezielt an Kinder unter 13 Jahren. Wir erheben wissentlich keine Daten von Kindern.</p>
+
+            <div class="sep">⸻</div>
+
+            <h2>7) Änderungen</h2>
+            <p>Diese Datenschutzerklärung kann angepasst werden, wenn sich Funktionen der App oder gesetzliche Anforderungen ändern (z.&nbsp;B. neue optionale Sync-Quellen oder Features). Die aktuelle Fassung findest du auf dieser Seite.</p>
+            <p class="update-note">Letzte Aktualisierung: 24. Mai 2026</p>
 
             <p><a class="back" href="/katoro.html" aria-label="Zurück zur katoro App-Seite">← Zurück zur katoro App-Seite</a></p>
         </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -31,6 +31,18 @@
     <priority>0.3</priority>
   </url>
   <url>
+    <loc>https://dwidmer.dev/katoro.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://dwidmer.dev/katoro-privacy.html</loc>
+    <lastmod>2026-05-24</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
     <loc>https://dwidmer.dev/impressum.html</loc>
     <lastmod>2025-01-08</lastmod>
     <changefreq>yearly</changefreq>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the placeholder on `katoro-privacy.html` with the complete seven-section privacy policy for the katoro iOS app (last updated May 24, 2026).

## Changes

- **katoro-privacy.html**: Full policy covering local data, Apple/Google/Microsoft services, ICS feeds, storage, sharing, user rights, children, and updates. Structure matches `monodot-privacy.html` (headings, lists, separators, external links).
- **Meta description**: Expanded for clearer SEO/snippets.
- **sitemap.xml**: Added `katoro.html` and `katoro-privacy.html` with `lastmod` 2026-05-24.

## Verification

- `npm run build` succeeds; `katoro-privacy.html` is included in the Vite multi-page build (~18 kB).

## App Store URL

Privacy policy URL: https://dwidmer.dev/katoro-privacy.html
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-680a6676-3068-4b6c-9e2f-0ba9dcbf89f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-680a6676-3068-4b6c-9e2f-0ba9dcbf89f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

