### PR TITLE
Move katoro children notice to overview fine print

### DIFF
--- a/katoro-privacy.html
+++ b/katoro-privacy.html
@@ -43,6 +43,7 @@
         h3 { font-size:1rem; margin-top:1.25rem; margin-bottom:.5rem; }
         ul { margin:.75rem 0; padding-left:1.5rem; }
         ul li { margin-bottom:.35rem; }
+        .fine-print { opacity:.55; font-size:.8rem; margin-top:.75rem; }
         .update-note { opacity:.6; font-size:.85rem; margin-top:1.5rem; }
 
         /* Footer */
@@ -100,6 +101,7 @@
             <p>katoro ist eine Planungs-App für Termine, Aufgaben und Routinen. Wir betreiben keine eigenen Server, auf denen deine Planungsinhalte gespeichert werden. Die Verarbeitung erfolgt überwiegend lokal auf deinem Gerät oder über Dienste, die du aktiv nutzt (z.&nbsp;B. Apple, optional Google oder Microsoft).</p>
             <p><strong>Werbung und Tracking:</strong> katoro zeigt keine Werbung und verwendet kein werbliches Tracking (kein AdMob o.&nbsp;Ä.).</p>
             <p><strong>Änderungen an der App:</strong> Wenn katoro durch Updates neue Funktionen erhält, die zusätzliche Daten betreffen, passen wir diese Erklärung an. Die jeweils aktuelle Fassung findest du auf dieser Seite.</p>
+            <p class="fine-print">Hinweis: katoro richtet sich nicht gezielt an Kinder unter 13 Jahren; wir erheben wissentlich keine Daten von Kindern.</p>
 
             <div class="sep">⸻</div>
 
@@ -183,12 +185,7 @@
 
             <div class="sep">⸻</div>
 
-            <h2>6) Kinder</h2>
-            <p>katoro richtet sich nicht gezielt an Kinder unter 13 Jahren. Wir erheben wissentlich keine Daten von Kindern.</p>
-
-            <div class="sep">⸻</div>
-
-            <h2>7) Änderungen</h2>
+            <h2>6) Änderungen</h2>
             <p>Diese Datenschutzerklärung kann angepasst werden, wenn sich Funktionen der App oder gesetzliche Anforderungen ändern (z.&nbsp;B. neue optionale Sync-Quellen oder Features). Die aktuelle Fassung findest du auf dieser Seite.</p>
             <p class="update-note">Letzte Aktualisierung: 24. Mai 2026</p>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the standalone **6) Kinder** section from the katoro privacy policy and places a shorter note in section **1) Überblick** as fine print.

## Changes

- Added `.fine-print` style (smaller, muted text)
- Overview now includes: *Hinweis: katoro richtet sich nicht gezielt an Kinder unter 13 Jahren; wir erheben wissentlich keine Daten von Kindern.*
- Former section **7) Änderungen** is now **6) Änderungen**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-680a6676-3068-4b6c-9e2f-0ba9dcbf89f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-680a6676-3068-4b6c-9e2f-0ba9dcbf89f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

